### PR TITLE
Fix repeating error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ let isError = false;
 let errorMsg = [];
 
 exports.isValidCronExpression = function(cronExpression, errorObj) {
+    isError = false;
+    errorMsg = [];
 
     if(!/\s/g.test(cronExpression)) {
         if(errorObj && errorObj.error) {


### PR DESCRIPTION
This should fix #17

This is caused by `isError` and `errorMsg` being global variables shared between `isValidCronExpression` calls. If you have a few invalid cron expressions validated in a sequence, `errorMsg` would keep the error messages from all previous expressions.

Resetting their values to defaults at the beginning of `isValidCronExpression` should solve that